### PR TITLE
Draft: Fix account number parsing in some abbreviated cases

### DIFF
--- a/lib/nz_bank_account_validator.rb
+++ b/lib/nz_bank_account_validator.rb
@@ -18,7 +18,8 @@ class NzBankAccountValidator
     end
   end
 
-  PATTERN = /\A^(?<bank_id>\d{1,2})[- ]?(?<bank_branch>\d{1,4})[- ]?(?<account_base_number>\d{1,8})[- ]?(?<account_suffix>\d{1,4})\z/.freeze
+  IBAN_PATTERN = /\A^(?<bank_id>\d{1,2})[- ]?(?<bank_branch>\d{1,4})[- ]?(?<account_base_number>\d{1,8})[- ]?(?<account_suffix>\d{1,4})\z/.freeze
+  NZBN_PATTERN = /\A^(?<bank_id>\d{2})[- ]?(?<bank_branch>\d{4})[- ]?(?<account_base_number>\d{7})[- ]?(?<account_suffix>\d{2,3})\z/.freeze
 
   RADIX = 10
 
@@ -76,8 +77,13 @@ class NzBankAccountValidator
     new(string).valid?
   end
 
-  def initialize(string)
-    match = string.match(PATTERN)
+  def initialize(string, iban: false)
+    if iban
+      match = string.match(IBAN_PATTERN)
+    else
+      match = string.match(NZBN_PATTERN)
+    end
+
     return unless match
 
     @bank_id = Integer(match[:bank_id], RADIX)

--- a/spec/nz_bank_account_validator_spec.rb
+++ b/spec/nz_bank_account_validator_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe NzBankAccountValidator do
   let(:ex1) { validator('01-902-0068389-00') }
   let(:ex2) { validator('08-6523-1954512-001') }
   let(:ex3) { validator('26-2600-0320871-032') }
+  let(:ex4) { validator('389004055424701') }
 
   it 'has a version number' do
     expect(NzBankAccountValidator::VERSION).not_to be nil
@@ -54,12 +55,14 @@ RSpec.describe NzBankAccountValidator do
       expect(ex1.algo_code).to eq(:a)
       expect(ex2.algo_code).to eq(:d)
       expect(ex3.algo_code).to eq(:g)
+      expect(ex4.algo_code).to eq(:b)
     end
   end
 
   describe '#number_for_checksum' do
     it 'should zero pad the 7 digit account number to 8 characters' do
       expect(validator('08-0123-0034141-03').number_for_checksum).to eq('080123000341410003')
+      expect(ex4.number_for_checksum).to eq('389004005542470001')
     end
   end
 
@@ -72,10 +75,11 @@ RSpec.describe NzBankAccountValidator do
   end
 
   describe '#valid_modulo?' do
-    it 'should valid modulo for the example in the pdf' do
+    it 'should valid modulo for the examples in the pdf' do
       expect(ex1).to be_valid_modulo
-      expect(ex1).to be_valid_modulo
-      expect(ex1).to be_valid_modulo
+      expect(ex2).to be_valid_modulo
+      expect(ex3).to be_valid_modulo
+      expect(ex4).to be_valid_modulo
     end
   end
 

--- a/spec/nz_bank_account_validator_spec.rb
+++ b/spec/nz_bank_account_validator_spec.rb
@@ -3,11 +3,11 @@
 require 'spec_helper'
 
 RSpec.describe NzBankAccountValidator do
-  def validator(string)
-    NzBankAccountValidator.new(string)
+  def validator(string, iban: false)
+    NzBankAccountValidator.new(string, iban: iban)
   end
 
-  let(:ex1) { validator('01-902-0068389-00') }
+  let(:ex1) { validator('01-902-0068389-00', iban: true) }
   let(:ex2) { validator('08-6523-1954512-001') }
   let(:ex3) { validator('26-2600-0320871-032') }
   let(:ex4) { validator('389004055424701') }
@@ -30,12 +30,12 @@ RSpec.describe NzBankAccountValidator do
       # VALIDS
       expect(validator('03-0123-0034141-03')).to be_valid_bank_branch
       expect(validator('26-2600-0034141-03')).to be_valid_bank_branch
-      expect(validator('26-2699-0034141-0003')).to be_valid_bank_branch
-      expect(validator('11-6666-0034141-0003')).to be_valid_bank_branch
+      expect(validator('26-2699-0034141-0003', iban: true)).to be_valid_bank_branch
+      expect(validator('11-6666-0034141-0003', iban: true)).to be_valid_bank_branch
 
       # INVALIDS
-      expect(validator('11-1111-0034141-0003')).to_not be_valid_bank_branch
-      expect(validator('01-2012-0034141-0003')).to_not be_valid_bank_branch
+      expect(validator('11-1111-0034141-0003', iban: true)).to_not be_valid_bank_branch
+      expect(validator('01-2012-0034141-0003', iban: true)).to_not be_valid_bank_branch
     end
   end
 
@@ -55,7 +55,7 @@ RSpec.describe NzBankAccountValidator do
       expect(ex1.algo_code).to eq(:a)
       expect(ex2.algo_code).to eq(:d)
       expect(ex3.algo_code).to eq(:g)
-      expect(ex4.algo_code).to eq(:b)
+      expect(ex4.algo_code).to eq(:a)
     end
   end
 


### PR DESCRIPTION
This number should be valid, ANZ reckons it is fine during the "pay a friend" screen. I believe the issue is the regex being too greedy while finding the base account number.

This isn't currently passing, i'll fix it when i figure out how.