### PR TITLE
Support NZBN format for bank account numbers.

### DIFF
--- a/lib/nz_bank_account_validator.rb
+++ b/lib/nz_bank_account_validator.rb
@@ -18,7 +18,8 @@ class NzBankAccountValidator
     end
   end
 
-  PATTERN = /\A^(?<bank_id>\d{1,2})[- ]?(?<bank_branch>\d{1,4})[- ]?(?<account_base_number>\d{1,8})[- ]?(?<account_suffix>\d{1,4})\z/.freeze
+  IBAN_PATTERN = /\A^(?<bank_id>\d{1,2})[- ]?(?<bank_branch>\d{1,4})[- ]?(?<account_base_number>\d{1,8})[- ]?(?<account_suffix>\d{1,4})\z/.freeze
+  NZBN_PATTERN = /\A^(?<bank_id>\d{2})[- ]?(?<bank_branch>\d{4})[- ]?(?<account_base_number>\d{7})[- ]?(?<account_suffix>\d{2,3})\z/.freeze
 
   RADIX = 10
 
@@ -76,8 +77,13 @@ class NzBankAccountValidator
     new(string).valid?
   end
 
-  def initialize(string)
-    match = string.match(PATTERN)
+  def initialize(string, iban: false)
+    if iban
+      match = string.match(IBAN_PATTERN)
+    else
+      match = string.match(NZBN_PATTERN)
+    end
+
     return unless match
 
     @bank_id = Integer(match[:bank_id], RADIX)

--- a/lib/nz_bank_account_validator.rb
+++ b/lib/nz_bank_account_validator.rb
@@ -31,7 +31,7 @@ class NzBankAccountValidator
     1  => BankDefinition.new(ranges: [1..999, 1100..1199, 1800..1899]),
     2  => BankDefinition.new(ranges: [1..999, 1200..1299]),
     3  => BankDefinition.new(ranges: [1..999, 1300..1399, 1500..1599, 1700..1799, 1900..1999, 7350..7399]),
-    4  => BankDefinition.new(ranges: [2020..2024]),
+    4  => BankDefinition.new(ranges: [2014..2024]),
     6  => BankDefinition.new(ranges: [1..999, 1400..1499]),
     8  => BankDefinition.new(ranges: [6500..6599], algo: :d),
     9  => BankDefinition.new(ranges: [0..0], algo: :e),

--- a/spec/nz_bank_account_validator_spec.rb
+++ b/spec/nz_bank_account_validator_spec.rb
@@ -3,13 +3,14 @@
 require 'spec_helper'
 
 RSpec.describe NzBankAccountValidator do
-  def validator(string)
-    NzBankAccountValidator.new(string)
+  def validator(string, iban: false)
+    NzBankAccountValidator.new(string, iban: iban)
   end
 
-  let(:ex1) { validator('01-902-0068389-00') }
+  let(:ex1) { validator('01-902-0068389-00', iban: true) }
   let(:ex2) { validator('08-6523-1954512-001') }
   let(:ex3) { validator('26-2600-0320871-032') }
+  let(:ex4) { validator('389004055424701') }
 
   it 'has a version number' do
     expect(NzBankAccountValidator::VERSION).not_to be nil
@@ -29,12 +30,12 @@ RSpec.describe NzBankAccountValidator do
       # VALIDS
       expect(validator('03-0123-0034141-03')).to be_valid_bank_branch
       expect(validator('26-2600-0034141-03')).to be_valid_bank_branch
-      expect(validator('26-2699-0034141-0003')).to be_valid_bank_branch
-      expect(validator('11-6666-0034141-0003')).to be_valid_bank_branch
+      expect(validator('26-2699-0034141-0003', iban: true)).to be_valid_bank_branch
+      expect(validator('11-6666-0034141-0003', iban: true)).to be_valid_bank_branch
 
       # INVALIDS
-      expect(validator('11-1111-0034141-0003')).to_not be_valid_bank_branch
-      expect(validator('01-2012-0034141-0003')).to_not be_valid_bank_branch
+      expect(validator('11-1111-0034141-0003', iban: true)).to_not be_valid_bank_branch
+      expect(validator('01-2012-0034141-0003', iban: true)).to_not be_valid_bank_branch
     end
   end
 
@@ -54,12 +55,14 @@ RSpec.describe NzBankAccountValidator do
       expect(ex1.algo_code).to eq(:a)
       expect(ex2.algo_code).to eq(:d)
       expect(ex3.algo_code).to eq(:g)
+      expect(ex4.algo_code).to eq(:a)
     end
   end
 
   describe '#number_for_checksum' do
     it 'should zero pad the 7 digit account number to 8 characters' do
       expect(validator('08-0123-0034141-03').number_for_checksum).to eq('080123000341410003')
+      expect(ex4.number_for_checksum).to eq('389004005542470001')
     end
   end
 
@@ -72,10 +75,11 @@ RSpec.describe NzBankAccountValidator do
   end
 
   describe '#valid_modulo?' do
-    it 'should valid modulo for the example in the pdf' do
+    it 'should valid modulo for the examples in the pdf' do
       expect(ex1).to be_valid_modulo
-      expect(ex1).to be_valid_modulo
-      expect(ex1).to be_valid_modulo
+      expect(ex2).to be_valid_modulo
+      expect(ex3).to be_valid_modulo
+      expect(ex4).to be_valid_modulo
     end
   end
 

--- a/spec/nz_bank_account_validator_spec.rb
+++ b/spec/nz_bank_account_validator_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe NzBankAccountValidator do
       expect(validator('03-0123-0034141-03')).to be_valid_bank_id
       expect(validator('01-1113-0034141-03')).to be_valid_bank_id
       expect(validator('20-0123-1111111-11')).to be_valid_bank_id
+      expect(validator('04-2015-0487252-00')).to be_valid_bank_id
       expect(validator('05-0123-0034141-03')).to_not be_valid_bank_id # no back 05
     end
   end
@@ -32,6 +33,7 @@ RSpec.describe NzBankAccountValidator do
       expect(validator('26-2600-0034141-03')).to be_valid_bank_branch
       expect(validator('26-2699-0034141-0003', iban: true)).to be_valid_bank_branch
       expect(validator('11-6666-0034141-0003', iban: true)).to be_valid_bank_branch
+      expect(validator('04-2015-0487252-00')).to be_valid_bank_branch
 
       # INVALIDS
       expect(validator('11-1111-0034141-0003', iban: true)).to_not be_valid_bank_branch
@@ -43,6 +45,7 @@ RSpec.describe NzBankAccountValidator do
     it 'should select the correct algo_code code' do
       expect(validator('08-0123-0034141-03').algo_code).to eq(:d)
       expect(validator('31-0123-0034141-03').algo_code).to eq(:x)
+      expect(validator('04-2015-0487252-00').algo_code).to eq(:a)
 
       # If the account base number is below 00990000 then apply algorithm A, otherwise apply algorithm B
       expect(validator('30-0123-0034141-03').algo_code).to eq(:a)
@@ -86,6 +89,7 @@ RSpec.describe NzBankAccountValidator do
   describe '#valid?' do
     it 'instance method' do
       expect(NzBankAccountValidator.new('08-6523-1954512-001')).to be_valid
+      expect(NzBankAccountValidator.new('04-2015-0487252-00')).to be_valid
     end
 
     it 'class method' do


### PR DESCRIPTION
The IRD document referenced in the README is an implementation of the NZ styled international banking format - which isn't commonly in use in New Zealand is pretty useless is a local format where we can make more assumptions to get a wider range of valid account numbers. Based on the wikipedia page here: https://en.wikipedia.org/wiki/New_Zealand_bank_account_number we can be a little more aggressive with some assumptions when we match the BB-bbbb-AAAAAAA-SSS format outlined.

Add a kiwibank test case number without spacing or hyphens. This number should be valid, ANZ reckons it is fine during the "pay a friend" screen. This number fails to validate prior to change, but we have made payments to this account successful with our real bank.